### PR TITLE
feat: 新增 Claude/Anthropic `/v1/messages` 兼容实现，并移除未上线历史别名路由

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ go run ./cmd/gptb2o-adk --auth-source codex --model chatgpt/codex/gpt-5.1 --inpu
 - `POST /v1/responses`（官方推荐）
   - `stream=true`：输出官方 SSE（`event:` + `data:`），并且不透传 backend 的 `data: [DONE]`
   - `stream=false`：从 backend SSE 的 `response.completed.response` 提取最终 JSON 返回
+- `POST /v1/messages`（Claude Code / Anthropic 官方路径）
+  - 入参兼容 Claude Messages API 的 `model/messages/system/stream/max_tokens`
+  - `stream=true`：返回 Claude 风格 SSE（`message_start/content_block_delta/.../message_stop`）
+  - `stream=false`：返回 Claude 风格 `message` JSON
 
 ## License
 
 All rights reserved.
-

--- a/openaihttp/claude.go
+++ b/openaihttp/claude.go
@@ -1,0 +1,337 @@
+package openaihttp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/LubyRuffy/gptb2o"
+	"github.com/LubyRuffy/gptb2o/backend"
+	"github.com/LubyRuffy/gptb2o/openaiapi"
+	einoModel "github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+	"github.com/google/uuid"
+)
+
+type claudeCompatConfig struct {
+	Now          func() time.Time
+	NewChatModel func(ctx context.Context, modelID string, tools []openaiapi.OpenAITool, toolCallHandler func(*backend.ToolCall)) (chatModel, error)
+	WriteJSON    func(w http.ResponseWriter, data interface{})
+	WriteError   func(w http.ResponseWriter, statusCode int, message string)
+}
+
+type claudeCompatHandler struct {
+	now          func() time.Time
+	newChatModel func(ctx context.Context, modelID string, tools []openaiapi.OpenAITool, toolCallHandler func(*backend.ToolCall)) (chatModel, error)
+	writeJSON    func(w http.ResponseWriter, data interface{})
+	writeError   func(w http.ResponseWriter, statusCode int, message string)
+}
+
+type claudeMessagesRequest struct {
+	Model     string             `json:"model"`
+	Messages  []claudeMessage    `json:"messages"`
+	System    claudeContentField `json:"system,omitempty"`
+	Stream    bool               `json:"stream"`
+	MaxTokens int                `json:"max_tokens"`
+}
+
+type claudeMessage struct {
+	Role    string             `json:"role"`
+	Content claudeContentField `json:"content"`
+}
+
+type claudeContentField struct {
+	raw json.RawMessage
+}
+
+func (f *claudeContentField) UnmarshalJSON(data []byte) error {
+	f.raw = append(f.raw[:0], data...)
+	return nil
+}
+
+type claudeContentText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type claudeMessageResponse struct {
+	ID           string              `json:"id"`
+	Type         string              `json:"type"`
+	Role         string              `json:"role"`
+	Model        string              `json:"model"`
+	Content      []claudeContentText `json:"content"`
+	StopReason   string              `json:"stop_reason"`
+	StopSequence *string             `json:"stop_sequence"`
+	Usage        claudeUsage         `json:"usage"`
+}
+
+type claudeUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+func newClaudeCompatHandler(cfg claudeCompatConfig) (*claudeCompatHandler, error) {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.NewChatModel == nil {
+		return nil, fmt.Errorf("NewChatModel is required")
+	}
+	if cfg.WriteJSON == nil {
+		return nil, fmt.Errorf("WriteJSON is required")
+	}
+	if cfg.WriteError == nil {
+		return nil, fmt.Errorf("WriteError is required")
+	}
+	return &claudeCompatHandler{
+		now:          cfg.Now,
+		newChatModel: cfg.NewChatModel,
+		writeJSON:    cfg.WriteJSON,
+		writeError:   cfg.WriteError,
+	}, nil
+}
+
+func (h *claudeCompatHandler) handleMessages(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var req claudeMessagesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if strings.TrimSpace(req.Model) == "" {
+		h.writeError(w, http.StatusBadRequest, "model is required")
+		return
+	}
+	if len(req.Messages) == 0 {
+		h.writeError(w, http.StatusBadRequest, "messages is required")
+		return
+	}
+
+	modelID := normalizeClaudeModel(req.Model)
+	if !gptb2o.IsSupportedModelID(modelID) {
+		h.writeError(w, http.StatusBadRequest, "unsupported model")
+		return
+	}
+	modelID = gptb2o.NormalizeModelID(modelID)
+
+	chatInput, err := convertClaudeMessages(req.System, req.Messages)
+	if err != nil {
+		h.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	chatModel, err := h.newChatModel(r.Context(), modelID, nil, nil)
+	if err != nil {
+		h.writeError(w, httpStatusFromError(err), httpMessageFromError(err))
+		return
+	}
+
+	if req.Stream {
+		h.writeMessagesStream(w, r, chatModel, modelID, chatInput)
+		return
+	}
+
+	respMsg, err := chatModel.Generate(r.Context(), chatInput, einoModel.WithTemperature(0))
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	text := ""
+	if respMsg != nil {
+		text = respMsg.Content
+	}
+	resp := claudeMessageResponse{
+		ID:         "msg_" + uuid.NewString(),
+		Type:       "message",
+		Role:       "assistant",
+		Model:      req.Model,
+		Content:    []claudeContentText{{Type: "text", Text: text}},
+		StopReason: "end_turn",
+		Usage:      claudeUsage{},
+	}
+	h.writeJSON(w, resp)
+}
+
+func (h *claudeCompatHandler) writeMessagesStream(w http.ResponseWriter, r *http.Request, chatModel chatModel, model string, chatInput []*schema.Message) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		h.writeError(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	sr, err := chatModel.Stream(r.Context(), chatInput)
+	if err != nil {
+		h.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	msgID := "msg_" + uuid.NewString()
+	startPayload := map[string]any{
+		"type": "message_start",
+		"message": claudeMessageResponse{
+			ID:         msgID,
+			Type:       "message",
+			Role:       "assistant",
+			Model:      model,
+			Content:    []claudeContentText{},
+			StopReason: "",
+			Usage:      claudeUsage{},
+		},
+	}
+	writeClaudeSSEEvent(w, flusher, "message_start", startPayload)
+	writeClaudeSSEEvent(w, flusher, "content_block_start", map[string]any{
+		"type":  "content_block_start",
+		"index": 0,
+		"content_block": map[string]any{
+			"type": "text",
+			"text": "",
+		},
+	})
+
+	for {
+		msg, err := sr.Recv()
+		if err != nil {
+			break
+		}
+		if msg == nil || strings.TrimSpace(msg.Content) == "" {
+			continue
+		}
+		writeClaudeSSEEvent(w, flusher, "content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": 0,
+			"delta": map[string]any{
+				"type": "text_delta",
+				"text": msg.Content,
+			},
+		})
+	}
+
+	writeClaudeSSEEvent(w, flusher, "content_block_stop", map[string]any{
+		"type":  "content_block_stop",
+		"index": 0,
+	})
+	writeClaudeSSEEvent(w, flusher, "message_delta", map[string]any{
+		"type": "message_delta",
+		"delta": map[string]any{
+			"stop_reason":   "end_turn",
+			"stop_sequence": nil,
+		},
+		"usage": claudeUsage{},
+	})
+	writeClaudeSSEEvent(w, flusher, "message_stop", map[string]any{"type": "message_stop"})
+}
+
+func writeClaudeSSEEvent(w http.ResponseWriter, flusher http.Flusher, event string, payload any) {
+	data, _ := json.Marshal(payload)
+	_, _ = fmt.Fprintf(w, "event: %s\n", event)
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", data)
+	flusher.Flush()
+}
+
+func convertClaudeMessages(system claudeContentField, messages []claudeMessage) ([]*schema.Message, error) {
+	result := make([]*schema.Message, 0, len(messages)+1)
+	if systemText, err := claudeContentToText(system); err != nil {
+		return nil, err
+	} else if strings.TrimSpace(systemText) != "" {
+		result = append(result, schema.SystemMessage(systemText))
+	}
+
+	for _, msg := range messages {
+		role := strings.TrimSpace(msg.Role)
+		if role == "" {
+			return nil, fmt.Errorf("message role is required")
+		}
+		text, err := claudeContentToText(msg.Content)
+		if err != nil {
+			return nil, err
+		}
+		text = strings.TrimSpace(text)
+		if text == "" {
+			continue
+		}
+		switch role {
+		case "user":
+			result = append(result, schema.UserMessage(text))
+		case "assistant":
+			result = append(result, schema.AssistantMessage(text, nil))
+		default:
+			return nil, fmt.Errorf("unsupported role: %s", role)
+		}
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no valid messages to send")
+	}
+	return result, nil
+}
+
+func claudeContentToText(content claudeContentField) (string, error) {
+	trimmed := strings.TrimSpace(string(content.raw))
+	if trimmed == "" || trimmed == "null" {
+		return "", nil
+	}
+	if trimmed[0] == '"' {
+		var text string
+		if err := json.Unmarshal(content.raw, &text); err != nil {
+			return "", fmt.Errorf("unsupported message content")
+		}
+		return text, nil
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(content.raw, &parts); err != nil {
+		return "", fmt.Errorf("unsupported message content")
+	}
+	var builder strings.Builder
+	for _, part := range parts {
+		if strings.TrimSpace(part.Type) != "text" {
+			continue
+		}
+		builder.WriteString(part.Text)
+	}
+	return builder.String(), nil
+}
+
+func normalizeClaudeModel(model string) string {
+	trimmed := strings.TrimSpace(model)
+	if strings.HasPrefix(trimmed, gptb2o.ModelNamespace) || strings.HasPrefix(trimmed, gptb2o.LegacyModelNamespace) {
+		return trimmed
+	}
+	return gptb2o.ModelNamespace + trimmed
+}
+
+func writeClaudeError(w http.ResponseWriter, statusCode int, message string) {
+	type claudeErrBody struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if statusCode <= 0 {
+		statusCode = http.StatusBadRequest
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	body := claudeErrBody{Type: "error"}
+	body.Error.Type = "invalid_request_error"
+	body.Error.Message = strings.TrimSpace(message)
+	if body.Error.Message == "" {
+		body.Error.Message = "request failed"
+	}
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/openaihttp/claude_test.go
+++ b/openaihttp/claude_test.go
@@ -1,0 +1,112 @@
+package openaihttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/LubyRuffy/gptb2o/backend"
+	"github.com/LubyRuffy/gptb2o/openaiapi"
+	einoModel "github.com/cloudwego/eino/components/model"
+	"github.com/cloudwego/eino/schema"
+	"github.com/stretchr/testify/require"
+)
+
+type stubChatModel struct {
+	generateResp *schema.Message
+	generateErr  error
+	streamMsgs   []*schema.Message
+	streamErr    error
+}
+
+func (s *stubChatModel) Generate(ctx context.Context, input []*schema.Message, opts ...einoModel.Option) (*schema.Message, error) {
+	return s.generateResp, s.generateErr
+}
+
+func (s *stubChatModel) Stream(ctx context.Context, input []*schema.Message, opts ...einoModel.Option) (*schema.StreamReader[*schema.Message], error) {
+	if s.streamErr != nil {
+		return nil, s.streamErr
+	}
+	return schema.StreamReaderFromArray(s.streamMsgs), nil
+}
+
+func TestClaudeMessages_NonStream_OK(t *testing.T) {
+	h, err := newClaudeCompatHandler(claudeCompatConfig{
+		Now: time.Now,
+		NewChatModel: func(ctx context.Context, modelID string, tools []openaiapi.OpenAITool, toolCallHandler func(*backend.ToolCall)) (chatModel, error) {
+			return &stubChatModel{generateResp: schema.AssistantMessage("pong", nil)}, nil
+		},
+		WriteJSON:  writeJSON,
+		WriteError: writeClaudeError,
+	})
+	require.NoError(t, err)
+
+	body := []byte(`{"model":"gpt-5.1","messages":[{"role":"user","content":"hello"}],"stream":false,"max_tokens":1024}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.handleMessages(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp claudeMessageResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "message", resp.Type)
+	require.Equal(t, "assistant", resp.Role)
+	require.Equal(t, "gpt-5.1", resp.Model)
+	require.Len(t, resp.Content, 1)
+	require.Equal(t, "text", resp.Content[0].Type)
+	require.Equal(t, "pong", resp.Content[0].Text)
+	require.Equal(t, "end_turn", resp.StopReason)
+}
+
+func TestClaudeMessages_Stream_OK(t *testing.T) {
+	h, err := newClaudeCompatHandler(claudeCompatConfig{
+		Now: time.Now,
+		NewChatModel: func(ctx context.Context, modelID string, tools []openaiapi.OpenAITool, toolCallHandler func(*backend.ToolCall)) (chatModel, error) {
+			return &stubChatModel{streamMsgs: []*schema.Message{{Content: "hello"}, {Content: " world"}}}, nil
+		},
+		WriteJSON:  writeJSON,
+		WriteError: writeClaudeError,
+	})
+	require.NoError(t, err)
+
+	body := []byte(`{"model":"gpt-5.1","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}],"stream":true,"max_tokens":1024}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.handleMessages(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+	out := w.Body.String()
+	require.Contains(t, out, "event: message_start\n")
+	require.Contains(t, out, "event: content_block_delta\n")
+	require.Contains(t, out, "\"text\":\"hello\"")
+	require.Contains(t, out, "\"text\":\" world\"")
+	require.Contains(t, out, "event: message_stop\n")
+}
+
+func TestClaudeMessages_BadRequest(t *testing.T) {
+	h, err := newClaudeCompatHandler(claudeCompatConfig{
+		Now: time.Now,
+		NewChatModel: func(ctx context.Context, modelID string, tools []openaiapi.OpenAITool, toolCallHandler func(*backend.ToolCall)) (chatModel, error) {
+			return &stubChatModel{}, nil
+		},
+		WriteJSON:  writeJSON,
+		WriteError: writeClaudeError,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader([]byte(`{"model":"","messages":[],"stream":false}`)))
+	w := httptest.NewRecorder()
+
+	h.handleMessages(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	data, readErr := io.ReadAll(w.Body)
+	require.NoError(t, readErr)
+	require.Contains(t, string(data), "model is required")
+}

--- a/openaihttp/gin.go
+++ b/openaihttp/gin.go
@@ -19,5 +19,10 @@ func RegisterGinRoutes(r gin.IRouter, cfg Config) error {
 	r.GET(joinPath(basePath, "/models"), gin.WrapF(modelsHandler))
 	r.POST(joinPath(basePath, "/chat/completions"), gin.WrapF(chatHandler))
 	r.POST(joinPath(basePath, "/responses"), gin.WrapF(responsesHandler))
+	claudeHandler, err := ClaudeMessagesHandler(cfg)
+	if err != nil {
+		return err
+	}
+	r.POST(joinPath(basePath, "/messages"), gin.WrapF(claudeHandler))
 	return nil
 }


### PR DESCRIPTION
### Motivation
- 提供对 Claude/Anthropic 官方 `Messages` 接口格式的兼容适配以支持非流与 Claude 风格流式（SSE）输出。 
- 既然功能尚未上线，去掉不必要的历史兼容别名以简化路由与行为（不再保留 `/v1/claude/messages`）。

### Description
- 新增 `openaihttp/claude.go`，实现对 Claude Messages 请求解析、`stream=true` 的 Claude 风格 SSE 输出与 `stream=false` 的 JSON 返回逻辑。 
- 新增单元测试 `openaihttp/claude_test.go`，覆盖非流返回、流式 SSE 输出与错误场景。 
- 在 `openaihttp/handlers.go` 中新增 `newChatModelFactory` 工厂函数并增加 `ClaudeMessagesHandler`，将 chat model 构造逻辑移入可复用工厂以简化注入。 
- 在 `openaihttp/gin.go` 中注册 `POST /v1/messages` 路由并移除历史别名路由，更新 `README.md` 中关于端点的描述。 

### Testing
- 运行 `go test ./...`，所有包测试通过（`openaihttp` 测试通过）。 
- 运行代码质量脚本 `./scripts/go_quality_check.sh` 时 `gofmt`、`go test` 与 `go vet` 步骤通过；`golangci-lint` 因构建环境中 `golangci-lint` 使用的 Go 版本低于项目目标版本而失败（环境限制）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698be3e083e8832ab328787242567e82)